### PR TITLE
Improve Angular packaging and Demo

### DIFF
--- a/demo-ng/App_Resources/iOS/Podfile
+++ b/demo-ng/App_Resources/iOS/Podfile
@@ -1,0 +1,1 @@
+platform :ios, '10.0'

--- a/demo-ng/package.json
+++ b/demo-ng/package.json
@@ -24,6 +24,7 @@
         "@nativescript-community/ui-material-slider": "file:../packages/slider",
         "@nativescript-community/ui-material-snackbar": "file:../packages/snackbar",
         "@nativescript-community/ui-material-textfield": "file:../packages/textfield",
+        "@nativescript-community/ui-material-tabs": "file:../packages/tabs",
         "@nativescript/theme": "~3.0.0",
         "reflect-metadata": "~0.1.13",
         "rxjs": "~6.6.3",

--- a/demo-ng/src/app/examples/examples.module.ts
+++ b/demo-ng/src/app/examples/examples.module.ts
@@ -9,6 +9,7 @@ import { SliderModule } from './slider/slider.module';
 import { ProgressModule } from './progress/progress.module';
 import { ActivityIndicatorModule } from './activity-indicator/activity-indicator.module';
 import { BottomNavigationBarModule } from './bottom-navigation-bar/bottom-navigation-bar.module';
+import { TabsModule } from './tabs/tabs.module';
 
 @NgModule({
     imports: [
@@ -21,7 +22,8 @@ import { BottomNavigationBarModule } from './bottom-navigation-bar/bottom-naviga
         SliderModule,
         ProgressModule,
         ActivityIndicatorModule,
-        BottomNavigationBarModule
+        BottomNavigationBarModule,
+        TabsModule
     ]
 })
 export class ExamplesModule {}

--- a/demo-ng/src/app/examples/examples.routing.ts
+++ b/demo-ng/src/app/examples/examples.routing.ts
@@ -11,6 +11,7 @@ import { SliderComponent } from './slider/slider.component';
 import { ProgressComponent } from './progress/progress.component';
 import { ActivityIndicatorComponent } from './activity-indicator/activity-indicator.component';
 import { BottomNavigationBarComponent } from './bottom-navigation-bar/bottom-navigation-bar.component';
+import { TabsComponent } from './tabs/tabs.component';
 // import { DialogComponent } from './dialog/dialog.component';
 
 const routes: Routes = [
@@ -49,6 +50,10 @@ const routes: Routes = [
     {
         path: 'bottom-navigation-bar',
         component: BottomNavigationBarComponent
+    },
+    {
+        path: 'tabs',
+        component: TabsComponent
     }
 ];
 

--- a/demo-ng/src/app/examples/tabs/tabs.component.html
+++ b/demo-ng/src/app/examples/tabs/tabs.component.html
@@ -1,0 +1,34 @@
+<MDTabs selectedIndex="1">
+  <!-- The bottom tab UI is created via TabStrip (the containier) and TabStripItem (for each tab)-->
+  <TabStrip>
+    <TabStripItem>
+      <Label text="Home"></Label>
+      <Image src="res://ic_home"></Image>
+    </TabStripItem>
+    <TabStripItem>
+      <Label text="Account"></Label>
+      <Image src="res://ic_view_list"></Image>
+    </TabStripItem>
+    <TabStripItem>
+      <Label text="Search"></Label>
+      <Image src="res://ic_menu"></Image>
+    </TabStripItem>
+  </TabStrip>
+
+  <!-- The number of TabContentItem components should corespond to the number of TabStripItem components -->
+  <TabContentItem>
+    <GridLayout>
+      <Label text="Home Page" class="h2 text-center"></Label>
+    </GridLayout>
+  </TabContentItem>
+  <TabContentItem>
+    <GridLayout>
+      <Label text="Account Page" class="h2 text-center"></Label>
+    </GridLayout>
+  </TabContentItem>
+  <TabContentItem>
+    <GridLayout>
+      <Label text="Search Page" class="h2 text-center"></Label>
+    </GridLayout>
+  </TabContentItem>
+</MDTabs>

--- a/demo-ng/src/app/examples/tabs/tabs.component.ts
+++ b/demo-ng/src/app/examples/tabs/tabs.component.ts
@@ -1,0 +1,10 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'ns-buttons',
+    templateUrl: './tabs.component.html',
+    moduleId: module.id
+})
+export class TabsComponent implements OnInit {
+    ngOnInit() { }
+}

--- a/demo-ng/src/app/examples/tabs/tabs.module.ts
+++ b/demo-ng/src/app/examples/tabs/tabs.module.ts
@@ -1,0 +1,11 @@
+import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
+import { NativeScriptCommonModule } from '@nativescript/angular';
+import { NativeScriptMaterialTabsModule } from '@nativescript-community/ui-material-tabs/angular';
+import { TabsComponent } from './tabs.component';
+
+@NgModule({
+    declarations: [TabsComponent],
+    imports: [NativeScriptCommonModule, NativeScriptMaterialTabsModule],
+    schemas: [NO_ERRORS_SCHEMA]
+})
+export class TabsModule {}

--- a/demo-ng/src/app/home/home.component.html
+++ b/demo-ng/src/app/home/home.component.html
@@ -1,19 +1,11 @@
-<ActionBar
-    title="Examples"
-    class="action-bar"
-></ActionBar>
+<ActionBar title="Examples" class="action-bar"></ActionBar>
 
 <GridLayout class="page">
-    <ListView
-        [items]="examples"
-        (itemTap)="goToExample($event)"
-        class="list-group"
-    >
+    <ListView [items]="examples" (itemTap)="goToExample($event)" class="list-group">
         <ng-template let-example="item">
-            <Label
-                [text]="example"
-                class="list-group-item"
-            ></Label>
+            <StackLayout>
+                <Label [text]="example" class="list-group-item"></Label>
+            </StackLayout>
         </ng-template>
     </ListView>
 </GridLayout>

--- a/demo-ng/src/app/home/home.component.ts
+++ b/demo-ng/src/app/home/home.component.ts
@@ -17,7 +17,8 @@ export class HomeComponent implements OnInit {
         'Ripple',
         'Text Field',
         'Slider',
-        'Progress'
+        'Progress',
+        'Tabs'
     ];
 
     constructor(private router: RouterExtensions) {}

--- a/src/activityindicator/angular/tsconfig.json
+++ b/src/activityindicator/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/appbar/angular/tsconfig.json
+++ b/src/appbar/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/bottomnavigationbar/angular/tsconfig.json
+++ b/src/bottomnavigationbar/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/bottomsheet/angular/tsconfig.json
+++ b/src/bottomsheet/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/button/angular/tsconfig.json
+++ b/src/button/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/cardview/angular/tsconfig.json
+++ b/src/cardview/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/floatingactionbutton/angular/tsconfig.json
+++ b/src/floatingactionbutton/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/progress/angular/tsconfig.json
+++ b/src/progress/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/ripple/angular/tsconfig.json
+++ b/src/ripple/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/slider/angular/tsconfig.json
+++ b/src/slider/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/tabs/angular/package.json
+++ b/src/tabs/angular/package.json
@@ -2,7 +2,7 @@
 	"name": "@nativescript-community/ui-material-tabs-angular",
 	"main": "index.js",
 	"ngPackage": {
-		"dest":"../../../tempAngular/tabs",
+		"dest":"../../../packages/tabs/angular",
 		"lib": {
 			"entryFile": "index.ts",
 			"umdModuleIds": {

--- a/src/tabs/angular/tsconfig.json
+++ b/src/tabs/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/textfield/angular/tsconfig.json
+++ b/src/textfield/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }

--- a/src/textview/angular/tsconfig.json
+++ b/src/textview/angular/tsconfig.json
@@ -12,4 +12,7 @@
         }
     },
     "include": ["./**/*.ts", "../../../references.d.ts", "../../references.d.ts"],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    }
 }


### PR DESCRIPTION
The purpose of this PR is as follows:
- ng-packagr dest setting for tabs/angular was not correct, now it's been set correctly.
- tnsconfig.json files in src/*/angular now have angularCompilerOptions.enableIvy set to false to fix ng-packagr warning about Ivy.
- A Tabs example has been added to ng-demo.
- The visual of Examples page has been slightly improved.
- Add Podfile with min version 10.0 to ng-demo App_Resources/iOS