### PR TITLE
helperColor property on TextField and TextView

### DIFF
--- a/src/core/textbase/cssproperties.ts
+++ b/src/core/textbase/cssproperties.ts
@@ -12,6 +12,13 @@ export const helperProperty = new CssProperty<Style, string>({
     cssName: 'helper'
 });
 helperProperty.register(Style);
+export const helperColorProperty = new CssProperty<Style, Color>({
+    name: 'helperColor',
+    cssName: 'helper-color',
+    equalityComparer: Color.equals,
+    valueConverter: v => new Color(v),
+});
+helperColorProperty.register(Style);
 export const errorProperty = new CssProperty<Style, string>({
     name: 'error',
     cssName: 'error'

--- a/src/textfield/textfield.android.ts
+++ b/src/textfield/textfield.android.ts
@@ -6,6 +6,7 @@ import {
     floatingColorProperty,
     floatingInactiveColorProperty,
     floatingProperty,
+    helperColorProperty,
     helperProperty,
     maxLengthProperty,
     strokeColorProperty,
@@ -130,6 +131,10 @@ export class TextField extends TextFieldBase {
         const floatingColor =
             this.floatingColor instanceof Color ? this.floatingColor.android : this.layoutView.getDefaultHintTextColor().getColorForState(stateSets.FOCUSED_STATE_SET, placeholderColor);
         this.layoutView.setDefaultHintTextColor(getColorStateList(floatingColor, placeholderColor));
+    }
+    [helperColorProperty.setNative](value) {
+        const color = value instanceof Color ? value.android : value;
+        this.layoutView.setHelperTextColor(android.content.res.ColorStateList.valueOf(color));
     }
 
     public requestFocus() {

--- a/src/textfield/textfield.common.ts
+++ b/src/textfield/textfield.common.ts
@@ -11,6 +11,7 @@ export abstract class TextFieldBase extends NTextField {
     closeOnReturn: boolean;
 
     @cssProperty helper: string;
+    @cssProperty helperColor: Color;
     @cssProperty maxLength: number;
     @cssProperty errorColor: Color;
     @cssProperty floating: boolean;

--- a/src/textfield/textfield.d.ts
+++ b/src/textfield/textfield.d.ts
@@ -12,6 +12,7 @@ export class TextField extends NTextField {
     nativeViewProtected: any;
 
     helper: string;
+    helperColor: Color;
     maxLength: number;
     errorColor: Color;
     floating: boolean;

--- a/src/textfield/textfield.ios.ts
+++ b/src/textfield/textfield.ios.ts
@@ -7,6 +7,7 @@ import {
     floatingColorProperty,
     floatingInactiveColorProperty,
     floatingProperty,
+    helperColorProperty,
     helperProperty,
     maxLengthProperty,
     strokeColorProperty,
@@ -314,6 +315,11 @@ export class TextField extends TextFieldBase {
     }
     [helperProperty.setNative](value: string) {
         this._controller.helperText = value;
+    }
+    [helperColorProperty.setNative](value: string | Color) {
+        const temp = typeof value === 'string' ? new Color(value) : value;
+        const color: UIColor = temp.ios;
+        this._controller.leadingUnderlineLabelTextColor = color;
     }
     [maxLengthProperty.setNative](value: number) {
         this._controller.characterCountMax = value;

--- a/src/textview/textview.android.ts
+++ b/src/textview/textview.android.ts
@@ -4,6 +4,7 @@ import {
     floatingColorProperty,
     floatingInactiveColorProperty,
     floatingProperty,
+    helperColorProperty,
     helperProperty,
     maxLengthProperty,
     strokeColorProperty,
@@ -104,6 +105,10 @@ export class TextView extends TextViewBase {
         this.layoutView.setHint(text);
     }
 
+    [helperColorProperty.setNative](value) {
+        const color = value instanceof Color ? value.android : value;
+        this.layoutView.setHelperTextColor(android.content.res.ColorStateList.valueOf(color));
+    }
     [placeholderColorProperty.setNative](value: Color) {
         const placeholderColor = value instanceof Color ? value.android : value;
         const floatingColor = this.floatingColor instanceof Color ? this.floatingColor.android : placeholderColor;

--- a/src/textview/textview.common.ts
+++ b/src/textview/textview.common.ts
@@ -7,6 +7,7 @@ export abstract class TextViewBase extends NSTextView {
     abstract clearFocus();
 
     @cssProperty helper: string;
+    @cssProperty helperColor: Color;
     @cssProperty maxLength: number;
     @cssProperty errorColor: Color;
     @cssProperty floating: boolean;

--- a/src/textview/textview.d.ts
+++ b/src/textview/textview.d.ts
@@ -12,6 +12,7 @@ export class TextView extends EditableTextBase {
     nativeViewProtected: any;
 
     helper: string;
+    helperColor: Color;
     maxLength: number;
     errorColor: Color;
     floating: boolean;

--- a/src/textview/textview.ios.ts
+++ b/src/textview/textview.ios.ts
@@ -6,6 +6,7 @@ import {
     floatingColorProperty,
     floatingInactiveColorProperty,
     floatingProperty,
+    helperColorProperty,
     helperProperty,
     maxLengthProperty,
     strokeColorProperty,
@@ -311,6 +312,11 @@ export class TextView extends TextViewBase {
     }
     [helperProperty.setNative](value: string) {
         this._controller.helperText = value;
+    }
+    [helperColorProperty.setNative](value: string | Color) {
+        const temp = typeof value === 'string' ? new Color(value) : value;
+        const color: UIColor = temp.ios;
+        this._controller.leadingUnderlineLabelTextColor = color;
     }
     [maxLengthProperty.setNative](value: number) {
         this._controller.characterCountMax = value;


### PR DESCRIPTION
This introduces a way to change the color of the helper text on the TextField or TextView components.

### Usage

```html
<MDTextField
    ...
    helper="help me!"
    helperColor="red"
    ...
></MDTextField>
```
or 
```css
MDTextField {
    helper-color: red;
}
```

## Examples

### iOS
![Screen Shot 2020-10-07 at 10 01 31 PM](https://user-images.githubusercontent.com/21955158/95406673-f1607f00-08e8-11eb-8496-c0b8b4e006a6.png)
### Android
<img width="390" alt="Screen Shot 2020-10-07 at 7 35 51 PM" src="https://user-images.githubusercontent.com/21955158/95406683-fae9e700-08e8-11eb-8053-cdae13e80920.png">
