### PR TITLE
Update README.md

### DIFF
--- a/packages/bottom-navigation/README.md
+++ b/packages/bottom-navigation/README.md
@@ -119,7 +119,13 @@ MDBottomNavigation TabStrip {
 ### NativeScript + Angular
 
 ```typescript
-import { NativeScriptMaterialTabsModule } from "@nativescript-community/ui-material-bottom-navigation/angular";
+import { BottomNavigation, TabContentItem, TabStrip, TabStripItem } from '@nativescript-community/ui-material-bottom-navigation';
+import { NativeScriptMaterialBottomNavigationModule } from "@nativescript-community/ui-material-bottom-navigation/angular";
+
+registerElement('MDBottomNavigation', () => BottomNavigation);
+registerElement('MDTabStrip', () => TabStrip);
+registerElement('MDTabStripItem', () => TabStripItem);
+registerElement('MDTabContentItem', () => TabContentItem);
 
 @NgModule({
     imports: [


### PR DESCRIPTION
It is not specified that you need to register elements + the class should be called NativeScriptMaterialBottomNavigationModule.