### PR TITLE
fix: prevent unload if nested modal [BottomSheet] 

### DIFF
--- a/src/bottomsheet/bottomsheet.ios.ts
+++ b/src/bottomsheet/bottomsheet.ios.ts
@@ -291,7 +291,7 @@ class UILayoutViewController extends UIViewController {
     viewDidDisappear(animated: boolean): void {
         super.viewDidDisappear(animated);
         const owner = this.owner.get();
-        if (owner && !owner.parent) {
+        if (owner && !owner.parent && !owner.modal) {
             owner.callUnloaded();
         }
     }


### PR DESCRIPTION
This fixes a weird case I encountered with nested modals on iOS.

I am using a BottomSheet as a "quick view" for an item and the user has the option to tap on an image in that, then that will launch a full screen "normal" modal which just allows the user to zoom in on the image. The user can dismiss that and go back to the first modal. My problem was that all click events stopped working on the first modal at this point. I discovered that `callUnloaded()` was being called through `viewDidDisappear()` when the second modal was launched, which is not desirable (I think). I added a check that sees if there is an attached modal on the view already.