### PR TITLE
feat(bottomnavigationbar) persist badge on pressed/selected

### DIFF
--- a/src/bottomnavigationbar/bottomnavigationbar-common.ts
+++ b/src/bottomnavigationbar/bottomnavigationbar-common.ts
@@ -89,7 +89,6 @@ export abstract class BottomNavigationBarBase extends View {
             index,
         };
         this.notify(eventData);
-        this.removeBadge(index);
     }
 
     _emitTabSelected(index: number) {
@@ -101,7 +100,6 @@ export abstract class BottomNavigationBarBase extends View {
         };
         this.selectedTabIndex = index;
         this.notify(eventData);
-        this.removeBadge(index);
     }
 
     _emitTabReselected(index: number) {

--- a/src/bottomnavigationbar/bottomnavigationbar-common.ts
+++ b/src/bottomnavigationbar/bottomnavigationbar-common.ts
@@ -34,6 +34,7 @@ export interface TabSelectedEventData extends EventData {
 export interface TabReselectedEventData extends EventData {
     index: number;
 }
+
 /**
  * Enum for Title Visibility options
  *
@@ -59,6 +60,7 @@ export abstract class BottomNavigationBarBase extends View {
 
     selectedTabIndex = 0;
     titleVisibility: TitleVisibility = TitleVisibility.always;
+    autoClearBadge: boolean;
 
     protected _items: BottomNavigationTabBase[] = [];
 
@@ -89,6 +91,10 @@ export abstract class BottomNavigationBarBase extends View {
             index,
         };
         this.notify(eventData);
+
+        if (this.autoClearBadge) {
+            this.removeBadge(index);
+        }
     }
 
     _emitTabSelected(index: number) {
@@ -100,6 +106,10 @@ export abstract class BottomNavigationBarBase extends View {
         };
         this.selectedTabIndex = index;
         this.notify(eventData);
+
+        if (this.autoClearBadge) {
+            this.removeBadge(index);
+        }
     }
 
     _emitTabReselected(index: number) {
@@ -147,6 +157,14 @@ export const titleVisibilityProperty = new Property<BottomNavigationBarBase, Tit
 });
 
 titleVisibilityProperty.register(BottomNavigationBarBase);
+
+export const autoClearBadgeProperty = new Property<BottomNavigationBarBase, boolean>({
+    name: 'autoClearBadge',
+    defaultValue: true,
+    valueConverter: booleanConverter,
+});
+
+autoClearBadgeProperty.register(BottomNavigationBarBase);
 
 export const activeColorCssProperty = new CssProperty<Style, Color>({
     name: 'activeColor',

--- a/src/bottomnavigationbar/bottomnavigationbar.d.ts
+++ b/src/bottomnavigationbar/bottomnavigationbar.d.ts
@@ -21,6 +21,7 @@ export declare class BottomNavigationBar extends BottomNavigationBarBase {
     activeColor: Color;
     inactiveColor: Color;
     backgroundColor: Color;
+    autoClearBadge: Boolean;
     selectTab(index: number): void;
     showBadge(index: number, value?: number): void;
     removeBadge(index: number): void;


### PR DESCRIPTION
Currently the badge is removed when the tab is pressed or selected.

I suggest we leave it up to the user to determine when to clear the badge. There's the case where the badge is showing a notification count that may change when reading/clearing notifications. Without this, we have to repeatedly show the badge during navigation.