### PR TITLE
[BottomSheet]Android skipCollapsedState

### DIFF
--- a/src/bottomsheet/bottomsheet-common.ts
+++ b/src/bottomsheet/bottomsheet-common.ts
@@ -29,6 +29,7 @@ export interface BottomSheetOptions {
     ignoreTopSafeArea?: boolean; // optional ios parameter to top safe area. Default is true
     ignoreBottomSafeArea?: boolean; // optional ios parameter to bottom safe area. Default is false
     disableDimBackground?: boolean; // optional parameter to remove the dim background
+    skipCollapsedState?: boolean; // optional Android parameter to skip midway state when view is greater than 50%. Default is false
 }
 
 export abstract class ViewWithBottomSheetBase extends View {

--- a/src/bottomsheet/bottomsheet.android.ts
+++ b/src/bottomsheet/bottomsheet.android.ts
@@ -122,6 +122,13 @@ export class ViewWithBottomSheet extends ViewWithBottomSheetBase {
                     // set to maximum possible value to prevent dragging the sheet between peek and expanded height
                     behavior.setPeekHeight(java.lang.Integer.MAX_VALUE);
                 }
+                const skipCollapsedState = !bottomSheetOptions.options || bottomSheetOptions.options.skipCollapsedState === true;
+                if (skipCollapsedState) {
+                    // directly expand the bottom sheet after start
+                    behavior.setState(com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED);
+                    // disable peek/collapsed state
+                    behavior.setSkipCollapsed(true);
+                }
 
                 if (owner && !owner.isLoaded) {
                     owner.callLoaded();


### PR DESCRIPTION
Disables the collapsed/peeked state of the bottomsheet when the initial view height is greater than 50% of the viewport. 
Unaware of how the iOS version functions let alone if something like this is needed in it.