### PR TITLE
fix: (iOS) fix trackingScrollView and peekHeight

### DIFF
--- a/src/bottomsheet/bottomsheet-common.ts
+++ b/src/bottomsheet/bottomsheet-common.ts
@@ -31,7 +31,7 @@ export interface BottomSheetOptions {
     ignoreBottomSafeArea?: boolean; // optional ios parameter to bottom safe area. Default is false
     disableDimBackground?: boolean; // optional parameter to remove the dim background
     skipCollapsedState?: boolean; // optional Android parameter to skip midway state when view is greater than 50%. Default is false
-    peekHeight?: number; // optional Android parameter to set the collapsed sheet height.
+    peekHeight?: number; // optional parameter to set the collapsed sheet height. To work on iOS you need to set trackingScrollView.
     ignoreKeyboardHeight: boolean; //(iOS only) A Boolean value that controls whether the height of the keyboard should affect the bottom sheet's frame when the keyboard shows on the screen. (Default: true)
 }
 

--- a/src/bottomsheet/bottomsheet.ios.ts
+++ b/src/bottomsheet/bottomsheet.ios.ts
@@ -415,7 +415,7 @@ export class ViewWithBottomSheet extends ViewWithBottomSheetBase {
         if (options.trackingScrollView) {
             const scrollView = this.getViewById(options.trackingScrollView);
             if (scrollView && scrollView.nativeViewProtected instanceof UIScrollView) {
-                bottomSheet.trackingScrollView = scrollView.nativeViewProtected;
+                (bottomSheet.presentationController as MDCBottomSheetPresentationController).trackingScrollView = scrollView.nativeViewProtected;
             }
         }
         controller.nsAnimated = true;


### PR DESCRIPTION
For a sheet to expand, you need to set the trackingScrollView according to the [documentation](https://github.com/material-components/material-components-ios/tree/develop/components/BottomSheet#expanding-bottom-sheet-example). Then I realized that it did not work. Now it is spreading and collapsing!