### PR TITLE
fix(bottom-navigation): Xcode 13 background-color correction

### DIFF
--- a/src/bottom-navigation/index.ios.ts
+++ b/src/bottom-navigation/index.ios.ts
@@ -217,7 +217,13 @@ function updateBackgroundPositions(tabStrip: TabStrip, tabStripItem: TabStripIte
     }
 
     const backgroundColor = tabStripItem.style.backgroundColor;
-    bgView.backgroundColor = backgroundColor instanceof Color ? backgroundColor.ios : backgroundColor;
+    if (backgroundColor) {
+        bgView.backgroundColor = backgroundColor instanceof Color ? backgroundColor.ios : backgroundColor;
+    } else {
+        // always default to at least a solid white background as fallback
+        // building with Xcode 13 causes bgView with no background to be fully transparent unless a css background-color is set - this allows original default behavior to work as it always did
+        bgView.backgroundColor = new Color('#fff').ios;
+    }
 }
 
 function updateTitleAndIconPositions(tabStripItem: TabStripItem, tabBarItem: UITabBarItem, controller: UIViewController) {


### PR DESCRIPTION
* This will solve the issue discussed in Discord recently: https://discord.com/channels/603595811204366337/751068755206864916/892445879129210920
* Tabstrip items would end up with completely transparent background colors and exhibit strange color behavior when switching tabs
* I contemplated using a majorVersion >= 15 to only apply for iOS 15 in the fallback however it doesn't matter. The default behavior was always to be white when no background-color was set so this just ensures standard behavior stays same as always but also ensure building with Xcode 13 or greater retains default behavior
* You can also add a class to each `MDTabStripItem` with a `background-color` set however I would not rely on developers doing this or leaving them to figure that out in this case