### PR TITLE
feat(bottom-navigation): Add safety check for owner

### DIFF
--- a/src/bottom-navigation/index.ios.ts
+++ b/src/bottom-navigation/index.ios.ts
@@ -52,11 +52,9 @@ class UITabBarControllerImpl extends UITabBarController {
     public viewDidDisappear(animated: boolean): void {
         super.viewDidDisappear(animated);
 
-        if (this._owner) {
-            const owner = this._owner.get();
-            if (owner && !owner.parent && owner.isLoaded && !this.presentedViewController) {
-                owner.callUnloaded();
-            }
+        const owner = this._owner?.get();
+        if (owner && !owner.parent && owner.isLoaded && !this.presentedViewController) {
+            owner.callUnloaded();
         }
     }
 

--- a/src/bottom-navigation/index.ios.ts
+++ b/src/bottom-navigation/index.ios.ts
@@ -51,9 +51,12 @@ class UITabBarControllerImpl extends UITabBarController {
     // @profile
     public viewDidDisappear(animated: boolean): void {
         super.viewDidDisappear(animated);
-        const owner = this._owner.get();
-        if (owner && !owner.parent && owner.isLoaded && !this.presentedViewController) {
-            owner.callUnloaded();
+
+        if (this._owner) {
+            const owner = this._owner.get();
+            if (owner && !owner.parent && owner.isLoaded && !this.presentedViewController) {
+                owner.callUnloaded();
+            }
         }
     }
 


### PR DESCRIPTION
On production I'm getting sporadic crashes on the `this._owner.get()` line of the bottom navigation. I'm guessing it happens in some suspend/kill situations as it does not occur very often. The PR adds a safety check if there is an owner before trying to call any methods on it. 