### PR TITLE
fix (bottomsheet ios) corrected width on safe areas

### DIFF
--- a/src/bottomsheet/bottomsheet.ios.ts
+++ b/src/bottomsheet/bottomsheet.ios.ts
@@ -189,8 +189,8 @@ function layoutView(controller: IUILayoutViewController, owner: View): void {
         owner.nativeViewProtected.frame = CGRectMake(
             Utils.layout.toDeviceIndependentPixels(adjustedPosition.left),
             Utils.layout.toDeviceIndependentPixels(adjustedPosition.top),
-            Utils.layout.toDeviceIndependentPixels(adjustedPosition.right - adjustedPosition.left),
-            Utils.layout.toDeviceIndependentPixels(adjustedPosition.bottom - adjustedPosition.top)
+            Utils.layout.toDeviceIndependentPixels(adjustedPosition.right),
+            Utils.layout.toDeviceIndependentPixels(adjustedPosition.bottom)
         );
     }
     controller.preferredContentSize = CGSizeMake(Utils.layout.toDeviceIndependentPixels(effectiveWidth), Utils.layout.toDeviceIndependentPixels(effectiveHeight));


### PR DESCRIPTION
* the right and bottom values erroneously subtract the left and top distances, respectively
* the error only appears when there are safe areas on the sides, for example on an iPhone X
* removing the subtraction is correcting this issue