### PR TITLE
iOS Slider numberOfDiscreteValues fix

### DIFF
--- a/src/slider/slider.ios.ts
+++ b/src/slider/slider.ios.ts
@@ -65,13 +65,17 @@ export class Slider extends SliderBase {
     [minValueProperty.setNative](value) {
         this.nativeViewProtected.minimumValue = value;
         if (this.stepSize !== 0) {
-            this.nativeViewProtected.numberOfDiscreteValues = (this.maxValue - this.minValue) / value;
+            // add one to get amount of values and not difference between min and max
+            const valuesCount = this.maxValue - this.minValue + 1;
+            this.nativeViewProtected.numberOfDiscreteValues = Math.ceil(valuesCount / value);
         }
     }
     [maxValueProperty.setNative](value) {
         this.nativeViewProtected.maximumValue = value;
         if (this.stepSize !== 0) {
-            this.nativeViewProtected.numberOfDiscreteValues = (this.maxValue - this.minValue) / value;
+            // add one to get amount of values and not difference between min and max
+            const valuesCount = this.maxValue - this.minValue + 1;
+            this.nativeViewProtected.numberOfDiscreteValues = Math.ceil(valuesCount / value);
         }
     }
     [stepSizeProperty.getDefault]() {
@@ -82,7 +86,11 @@ export class Slider extends SliderBase {
             this.nativeViewProtected.discrete = false;
         } else {
             this.nativeViewProtected.discrete = true;
-            this.nativeViewProtected.numberOfDiscreteValues = (this.maxValue - this.minValue) / value;
+
+            // add one to get amount of values and not difference between min and max
+            const valuesCount = this.maxValue - this.minValue + 1;
+            this.nativeViewProtected.numberOfDiscreteValues = Math.ceil(valuesCount / value);
+
             this.nativeViewProtected.shouldDisplayDiscreteValueLabel = false;
         }
     }


### PR DESCRIPTION
Here's a small fix on iOS so that `numberOfDiscreteValues` has the correct value.

With the previous logic the slider resulted in always being continuous as it calculated the min/max difference rather than the amount of values in the range.

**Examples**

**Range** 0 - 10
**Steps** 1

**Calculation** 10 - 0 / 1 = 10
**New Calculation** (10 - 0 + 1) / 1 = 11

<hr>

**Range** 5 - 100
**Steps** 5
**Calculation** 100 - 5 / 5 = 19
**New Calculation** (100 - 5 + 1) / 5 = 20 (Actual value is 19.2 but code is using `Math.ceil()` to get a whole number)
<hr>

Tested this locally on my project, unfortunately I wasn't able to run the demo apps within this project itself. But I think it should be fine.

Let me know if any other updates are required.