### PR TITLE
feat(BottomSheet): (Android only) allows to interact with the screen behind the sheet

### DIFF
--- a/src/bottomsheet/bottomsheet-common.ts
+++ b/src/bottomsheet/bottomsheet-common.ts
@@ -43,6 +43,7 @@ export interface BottomSheetOptions {
     peekHeight?: number; // optional parameter to set the collapsed sheet height. To work on iOS you need to set trackingScrollView.
     ignoreKeyboardHeight?: boolean; //(iOS only) A Boolean value that controls whether the height of the keyboard should affect the bottom sheet's frame when the keyboard shows on the screen. (Default: true)
     onChangeState?: onChangeStateBottomSheet; // One works to be called on the scroll of the sheet. Parameters: state (CLOSED, DRAGGING, DRAGGING, COLLAPSED) and slideOffset is the new offset of this bottom sheet within [-1,1] range. Offset increases as this bottom sheet is moving upward. From 0 to 1 the sheet is between collapsed and expanded states and from -1 to 0 it is between hidden and collapsed states.
+    canTouchBehind?: boolean //(Android only) allows to interact with the screen behind the sheet. For it to work properly need dismissOnBackgroundTap set to true
 }
 
 export abstract class ViewWithBottomSheetBase extends View {

--- a/src/bottomsheet/bottomsheet.android.ts
+++ b/src/bottomsheet/bottomsheet.android.ts
@@ -199,7 +199,7 @@ export class ViewWithBottomSheet extends ViewWithBottomSheetBase {
                 if(bottomSheetOptions.options.canTouchBehind){
                     const coordinator = view.getParent();
                     coordinator.findViewById(getId("touch_outside")).setOnTouchListener(new android.view.View.OnTouchListener({
-                        onTouch: function (a, event) {
+                        onTouch: function (view, event) {
                           fragment.getActivity().dispatchTouchEvent(event)
                           return false;
                         }

--- a/src/bottomsheet/bottomsheet.android.ts
+++ b/src/bottomsheet/bottomsheet.android.ts
@@ -200,7 +200,7 @@ export class ViewWithBottomSheet extends ViewWithBottomSheetBase {
                     const coordinator = view.getParent();
                     coordinator.findViewById(getId("touch_outside")).setOnTouchListener(new android.view.View.OnTouchListener({
                         onTouch: function (view, event) {
-                          fragment.getActivity().dispatchTouchEvent(event)
+                          fragment.getActivity().dispatchTouchEvent(event);
                           return false;
                         }
                     }));

--- a/src/bottomsheet/bottomsheet.android.ts
+++ b/src/bottomsheet/bottomsheet.android.ts
@@ -196,6 +196,16 @@ export class ViewWithBottomSheet extends ViewWithBottomSheetBase {
                     owner.callLoaded();
                 }
 
+                if(bottomSheetOptions.options.canTouchBehind){
+                    const coordinator = view.getParent();
+                    coordinator.findViewById(getId("touch_outside")).setOnTouchListener(new android.view.View.OnTouchListener({
+                        onTouch: function (a, event) {
+                          fragment.getActivity().dispatchTouchEvent(event)
+                          return false;
+                        }
+                    }));
+                }
+                
                 bottomSheetOptions.shownCallback();
             },
 


### PR DESCRIPTION
When you have a sheet open in the middle of the screen you cannot interact with the screen behind it, this PR adds that you can interact.

For now it only supports Android, I want to make it work for iOS too

old behavior:
https://user-images.githubusercontent.com/15719383/184112618-12c07bbb-1b10-418d-809c-f19a5f81a4bd.mp4

new behavior:
https://user-images.githubusercontent.com/15719383/184112497-45eca734-d8c3-4fa8-849f-a3bd73fce1cc.mp4



