### PR TITLE
fix(android): tab memory leak

### DIFF
--- a/src/core-tabs/tab-content-item/index.android.ts
+++ b/src/core-tabs/tab-content-item/index.android.ts
@@ -50,7 +50,7 @@ export class TabContentItem extends TabContentItemBase {
             }
         }
         if (!tabFragment) {
-            return fragmentManager;
+            return tabView._getRootFragmentManager();
         }
         return tabFragment.getChildFragmentManager();
     }


### PR DESCRIPTION
The tab view is leaking and retaining the FragmentClass 