### PR TITLE
fix(BottomSheet): Back to blade motion is fluid

### DIFF
--- a/packages/bottomsheet/README.md
+++ b/packages/bottomsheet/README.md
@@ -74,6 +74,7 @@ export interface BottomSheetOptions {
     //(iOS only) A Boolean value that controls whether the height of the keyboard should affect the bottom sheet's frame when the keyboard shows on the screen. (Default: true)
     onChangeState?: onChangeStateBottomSheet; 
     // One works to be called on the scroll of the sheet. Parameters: state (CLOSED, DRAGGING, DRAGGING, COLLAPSED) and slideOffset is the new offset of this bottom sheet within [-1,1] range. Offset increases as this bottom sheet is moving upward. From 0 to 1 the sheet is between collapsed and expanded states and from -1 to 0 it is between hidden and collapsed states.
+    canTouchBehind?: boolean //(Android only) allows to interact with the screen behind the sheet. For it to work properly need dismissOnBackgroundTap set to true.
 }
 ```
 

--- a/src/bottomsheet/bottomsheet.android.ts
+++ b/src/bottomsheet/bottomsheet.android.ts
@@ -198,6 +198,8 @@ export class ViewWithBottomSheet extends ViewWithBottomSheetBase {
                 }
 
                 if (bottomSheetOptions.options.canTouchBehind) {
+                    // necessary for smooth movement of the back page
+                    fragment.getDialog().getWindow().setFlags(android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE, android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
                     const coordinator = view.getParent();
                     if (coordinator instanceof android.view.View) {
                         coordinator.findViewById(getId('touch_outside')).setOnTouchListener(


### PR DESCRIPTION
When we have a map behind the sheet the movement becomes slow, when we add this flag the map becomes fluid to touch and movement without any problem

Before:
https://user-images.githubusercontent.com/15719383/195977059-b3e5875c-6760-40cc-9ea3-41fc519baee7.mp4

After:
https://user-images.githubusercontent.com/15719383/195977071-559b02f4-15dd-43fe-8748-d5e9020db287.mp4

Note how the movement of the map when the sheet is opened or when it is open has lag and with the flag this problem disappears

