### PR TITLE
Update to NS 8.4

### DIFF
--- a/src/textfield/textfield.android.ts
+++ b/src/textfield/textfield.android.ts
@@ -39,7 +39,7 @@ import {
 } from '@nativescript/core';
 import { secureProperty } from '@nativescript/core/ui/text-field';
 import { TextFieldBase } from './textfield.common';
-import { layout } from '@nativescript/core/utils';
+import { layout } from '@nativescript/core/utils/layout-helper';
 
 let LayoutInflater: typeof android.view.LayoutInflater;
 let FrameLayoutLayoutParams: typeof android.widget.FrameLayout.LayoutParams;

--- a/src/textfield/textfield.ios.old.ts
+++ b/src/textfield/textfield.ios.old.ts
@@ -32,7 +32,7 @@ import {
     placeholderColorProperty
 } from '@nativescript/core';
 import { textProperty } from '@nativescript/core/ui/text-base';
-import { layout } from '@nativescript/core/utils';
+import { layout } from '@nativescript/core/utils/layout-helper';
 import { TextFieldBase } from './textfield.common';
 
 @NativeClass

--- a/src/textfield/textfield.ios.ts
+++ b/src/textfield/textfield.ios.ts
@@ -38,7 +38,7 @@ import {
 } from '@nativescript/core';
 import { textProperty } from '@nativescript/core/ui/text-base';
 import { TextFieldBase } from './textfield.common';
-import { layout } from '@nativescript/core/utils';
+import { layout } from '@nativescript/core/utils/layout-helper';
 
 @NativeClass
 class MDCFilledTextFieldImpl extends MDCFilledTextField {


### PR DESCRIPTION
@farfromrefug I've checked all the `ui-material-components` I think that only the textfield that is require update .. I am not sure because I've updated the plugin that I use and I see errors!

I think the main change are the `layout` import from mainly UI plugins, and there some think bizarre with the WeakRef that become an `interface` instead !! 