### PR TITLE
fix(tabs): active tabitem isn't visible

### DIFF
--- a/packages/core-tabs/platforms/android/java/com/nativescript/material/core/TabsBar.java
+++ b/packages/core-tabs/platforms/android/java/com/nativescript/material/core/TabsBar.java
@@ -418,8 +418,15 @@ public class TabsBar extends HorizontalScrollView {
                 return;
             }
             mTabStrip.onTabsViewPagerPageChanged(position, positionOffset);
+            if (positionOffset == 0 && mScrollState == androidx.viewpager.widget.ViewPager.SCROLL_STATE_SETTLING) {
+                scrollToTab(position, 0);
+            }
         }
 
+        @Override
+        public void onPageScrollStateChanged (int state) {
+            mScrollState = state;
+        }
     }
 
     private class TabClickListener implements OnClickListener {


### PR DESCRIPTION
When we have more tabs and swipe to the left tab pages, but the corresponding active tab is not showing, we need to scroll the tabor to the left to see the active tab.

Please see the issue being reproduced:
https://user-images.githubusercontent.com/5738416/206513840-c6c0ce95-094b-402e-aa1e-443b88dfe4f0.mov


Please see the behavior after the bugfix applied:
https://user-images.githubusercontent.com/5738416/206513952-449bd80f-012c-4be8-bc4b-fb10373651a1.mp4


