### PR TITLE
fix(android): TabStrip style for the unselected item is not working

### DIFF
--- a/src/core-tabs/tab-navigation/index.android.ts
+++ b/src/core-tabs/tab-navigation/index.android.ts
@@ -587,7 +587,7 @@ export abstract class TabNavigation<T extends android.view.ViewGroup = any> exte
         if (!tabStripItem.nativeViewProtected) {
             return;
         }
-        const itemColor = tabStripItem.index === this.selectedIndex ? this.mSelectedItemColor : tabStripItem.style.color || this.mUnSelectedItemColor;
+        const itemColor = tabStripItem.index === this.selectedIndex ? this.mSelectedItemColor : this.mUnSelectedItemColor || tabStripItem.style.color;
         // set label color
         if (itemColor) {
             tabStripItem.nativeViewProtected.setTextColor(itemColor.android || null);


### PR DESCRIPTION
TabStrip style for the unselected item is not working.


Example CSS file:
```css
MDTabStrip {
  background-color: #79d2a6;
  selected-item-color: red;
  un-selected-item-color: yellow;
  highlight-color: red;
}

TabStripClassStyle MDTabStripItem {
  background-color: #79d2a6;
}
```

Before bugfix:
https://user-images.githubusercontent.com/5738416/219018760-5b8756a3-85e1-4f3b-80cb-fb21084a0c8f.mp4


After bugfix:
https://user-images.githubusercontent.com/5738416/219018836-c5ee6a6a-a258-4b95-98b0-dc6f3acde74c.mp4


Resolution: 
   The mUnSelectedItemColor filled up on the CSS file should have greater priority than the default color.
 
