### PR TITLE
feat: add vue2 & vue3 listener support to bottomsheet

### DIFF
--- a/demo-snippets/vue/BottomSheet.vue
+++ b/demo-snippets/vue/BottomSheet.vue
@@ -43,6 +43,9 @@ export default Vue.extend({
                 case 'bottomsheet': {
                     (this as NativeScriptVue).$showBottomSheet(BottomSheetInner, {
                         // transparent: true,
+                        on: {
+                            indexChanged: (x) => { console.log('listener', x) }
+                        },
                         closeCallback: (...args) => {
                             console.log('bottom sheet closed', args);
                         }

--- a/demo-snippets/vue/BottomSheetInner.vue
+++ b/demo-snippets/vue/BottomSheetInner.vue
@@ -2,6 +2,7 @@
     <GridLayout id="test1" rows="auto auto" backgroundColor="yellow">
         <!-- highlighted in red to demonstrate movement -->
         <Stacklayout id="test2" row="0" backgroundColor="red" verticalAlignment="top" marginLeft="10" marginRight="10">
+            <Button @tap="$emit('indexChanged', 200)" text="Emit value"></Button>
             <Button @tap="toggleExtraContent" text="Toggle extra content"></Button>
             <Button @tap="openAnotherInner" text="Open second"></Button>
             <Button id="innerButton" @tap="onButtonTap" text="close with result"></Button>

--- a/demo-snippets/vue3/BottomSheet.vue
+++ b/demo-snippets/vue3/BottomSheet.vue
@@ -1,7 +1,7 @@
 <template>
     <Page>
         <ActionBar :title="title">
-            <NavigationButton text="Back" android.systemIcon="ic_menu_back" @tap="onNavigationButtonTap"></NavigationButton>
+            <NavigationButton text="Back"  @tap="onNavigationButtonTap"></NavigationButton>
         </ActionBar>
         <StackLayout>
             <MDButton id="bottomsheet" text="bottomsheet" @tap="onTap" />
@@ -14,93 +14,89 @@
     </Page>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { EventData, View } from '@nativescript/core';
 import * as frameModule from '@nativescript/core/ui/frame';
 import { NativeScriptVue } from 'nativescript-vue';
-import Vue from 'vue';
+import { inject } from 'vue';
 import BottomSheetInner from './BottomSheetInner.vue';
 import BottomSheetInnerKeyboard from './BottomSheetInnerKeyboard.vue';
 
-export const title = 'BottomSheet sample';
+const title = 'BottomSheet sample';
+const name = 'BottomSheet';
+const $showBottomSheet = inject('$showBottomSheet')
 
-export default Vue.extend({
-    data() {
-        return {
-            name: 'BottomSheet',
-            title
-        };
-    },
-    methods: {
-        onNavigationButtonTap() {
-            frameModule.Frame.topmost().goBack();
-        },
-        onTap(args: EventData) {
-            const obj = args.object as View;
-            const objId = obj.id;
-            console.log('onTap', objId, obj);
-            switch (objId) {
-                case 'bottomsheet': {
-                    (this as NativeScriptVue).$showBottomSheet(BottomSheetInner, {
-                        // transparent: true,
-                        closeCallback: (...args) => {
-                            console.log('bottom sheet closed', args);
-                        }
-                    });
-                    break;
+function onNavigationButtonTap() {
+    frameModule.Frame.topmost().goBack();
+}
+
+function onTap(args: EventData) {
+    const obj = args.object as View;
+    const objId = obj.id;
+    console.log('onTap', objId, obj);
+    switch (objId) {
+        case 'bottomsheet': {
+            $showBottomSheet(BottomSheetInner, {
+                // transparent: true,
+                on: {
+                    indexChanged: (x) => { console.log('listener', x) }
+                },
+                closeCallback: (...args) => {
+                    console.log('bottom sheet closed', args);
                 }
-                case 'dont_ignore_top_safe_area': {
-                    (this as NativeScriptVue).$showBottomSheet(BottomSheetInner, {
-                        ignoreTopSafeArea: false,
-                        // transparent:true,
-                        closeCallback: (...args) => {
-                            console.log('bottom sheet closed', args);
-                        }
-                    });
-                    break;
+            });
+            break;
+        }
+        case 'dont_ignore_top_safe_area': {
+            $showBottomSheet(BottomSheetInner, {
+                ignoreTopSafeArea: false,
+                // transparent:true,
+                closeCallback: (...args) => {
+                    console.log('bottom sheet closed', args);
                 }
-                case 'ignore_bottom_safe_area': {
-                    (this as NativeScriptVue).$showBottomSheet(BottomSheetInner, {
-                        // transparent:true,
-                        ignoreBottomSafeArea: true,
-                        closeCallback: (...args) => {
-                            console.log('bottom sheet closed', args);
-                        }
-                    });
-                    break;
+            });
+            break;
+        }
+        case 'ignore_bottom_safe_area': {
+            $showBottomSheet(BottomSheetInner, {
+                // transparent:true,
+                ignoreBottomSafeArea: true,
+                closeCallback: (...args) => {
+                    console.log('bottom sheet closed', args);
                 }
-                case 'dont_ignore_top_ignore_bottom_safe_area': {
-                    (this as NativeScriptVue).$showBottomSheet(BottomSheetInner, {
-                        // transparent:true,
-                        ignoreTopSafeArea: false,
-                        ignoreBottomSafeArea: true,
-                        closeCallback: (...args) => {
-                            console.log('bottom sheet closed', args);
-                        }
-                    });
-                    break;
+            });
+            break;
+        }
+        case 'dont_ignore_top_ignore_bottom_safe_area': {
+            $showBottomSheet(BottomSheetInner, {
+                // transparent:true,
+                ignoreTopSafeArea: false,
+                ignoreBottomSafeArea: true,
+                closeCallback: (...args) => {
+                    console.log('bottom sheet closed', args);
                 }
-                case 'bottomsheet-keyboard': {
-                    (this as NativeScriptVue).$showBottomSheet(BottomSheetInnerKeyboard, {
-                        closeCallback: (...args) => {
-                            console.log('bottom sheet closed', args);
-                        }
-                    });
-                    break;
+            });
+            break;
+        }
+        case 'bottomsheet-keyboard': {
+            $showBottomSheet(BottomSheetInnerKeyboard, {
+                closeCallback: (...args) => {
+                    console.log('bottom sheet closed', args);
                 }
-                case 'bottomsheet-peekheight': {
-                    (this as NativeScriptVue).$showBottomSheet(BottomSheetInner, {
-                        peekHeight: 100,
-                        trackingScrollView: 'scrollView',
-                        // transparent: true,
-                        closeCallback: (...args) => {
-                            console.log('bottom sheet closed', args);
-                        }
-                    });
-                    break;
+            });
+            break;
+        }
+        case 'bottomsheet-peekheight': {
+            $showBottomSheet(BottomSheetInner, {
+                peekHeight: 100,
+                trackingScrollView: 'scrollView',
+                // transparent: true,
+                closeCallback: (...args) => {
+                    console.log('bottom sheet closed', args);
                 }
-            }
+            });
+            break;
         }
     }
-});
+}
 </script>

--- a/demo-snippets/vue3/BottomSheet.vue
+++ b/demo-snippets/vue3/BottomSheet.vue
@@ -18,14 +18,14 @@
 import { EventData, View } from '@nativescript/core';
 import * as frameModule from '@nativescript/core/ui/frame';
 import { NativeScriptVue } from 'nativescript-vue';
-import { inject } from 'vue';
 import BottomSheetInner from './BottomSheetInner.vue';
 import BottomSheetInnerKeyboard from './BottomSheetInnerKeyboard.vue';
+import { useBottomSheet } from "@nativescript-community/ui-material-bottomsheet/vue3";
 
 const title = 'BottomSheet sample';
 const name = 'BottomSheet';
-const $showBottomSheet = inject('$showBottomSheet')
 
+const { showBottomSheet, closeBottomSheet } = useBottomSheet()
 function onNavigationButtonTap() {
     frameModule.Frame.topmost().goBack();
 }
@@ -36,7 +36,7 @@ function onTap(args: EventData) {
     console.log('onTap', objId, obj);
     switch (objId) {
         case 'bottomsheet': {
-            $showBottomSheet(BottomSheetInner, {
+            showBottomSheet(BottomSheetInner, {
                 // transparent: true,
                 on: {
                     indexChanged: (x) => { console.log('listener', x) }
@@ -48,7 +48,7 @@ function onTap(args: EventData) {
             break;
         }
         case 'dont_ignore_top_safe_area': {
-            $showBottomSheet(BottomSheetInner, {
+            showBottomSheet(BottomSheetInner, {
                 ignoreTopSafeArea: false,
                 // transparent:true,
                 closeCallback: (...args) => {
@@ -58,7 +58,7 @@ function onTap(args: EventData) {
             break;
         }
         case 'ignore_bottom_safe_area': {
-            $showBottomSheet(BottomSheetInner, {
+            showBottomSheet(BottomSheetInner, {
                 // transparent:true,
                 ignoreBottomSafeArea: true,
                 closeCallback: (...args) => {
@@ -68,7 +68,7 @@ function onTap(args: EventData) {
             break;
         }
         case 'dont_ignore_top_ignore_bottom_safe_area': {
-            $showBottomSheet(BottomSheetInner, {
+            showBottomSheet(BottomSheetInner, {
                 // transparent:true,
                 ignoreTopSafeArea: false,
                 ignoreBottomSafeArea: true,
@@ -79,7 +79,7 @@ function onTap(args: EventData) {
             break;
         }
         case 'bottomsheet-keyboard': {
-            $showBottomSheet(BottomSheetInnerKeyboard, {
+            showBottomSheet(BottomSheetInnerKeyboard, {
                 closeCallback: (...args) => {
                     console.log('bottom sheet closed', args);
                 }
@@ -87,7 +87,7 @@ function onTap(args: EventData) {
             break;
         }
         case 'bottomsheet-peekheight': {
-            $showBottomSheet(BottomSheetInner, {
+            showBottomSheet(BottomSheetInner, {
                 peekHeight: 100,
                 trackingScrollView: 'scrollView',
                 // transparent: true,

--- a/demo-snippets/vue3/BottomSheetInner.vue
+++ b/demo-snippets/vue3/BottomSheetInner.vue
@@ -12,15 +12,6 @@
                 <MDTextField hint="Edit text to filter..." style="font-size: 16" />
                 <MDActivityIndicator *ngIf="processing" width="50" height="50" />
             </StackLayout>
-            <ListView height="150" :items="items" id="scrollView">
-                <v-template let-item="item" let-odd="odd" let-even="even">
-                    <GridLayout height="64" backgroundColor="green">
-                        <Image horizontalAlignment="left" width="64" />
-                        <Label horizontalAlignment="center" />
-                        <Label horizontalAlignment="right" />
-                    </GridLayout>
-                </v-template>
-            </ListView>
             <Button text="Cancel" horizontalAlignment="center" />
         </StackLayout>
     </GridLayout>
@@ -30,16 +21,14 @@
 <script lang="ts" setup>
 import * as frameModule from '@nativescript/core/ui/frame';
 import BottomSheetInnerKeyboardVue from './BottomSheetInnerKeyboard.vue';
-import { inject } from 'vue';
-
-const $closeBottomSheet = inject('$closeBottomSheet');
-const $showBottomSheet = inject('$showBottomSheet');
+import { useBottomSheet } from "@nativescript-community/ui-material-bottomsheet/vue3";
+const { showBottomSheet, closeBottomSheet } = useBottomSheet()
 
 const showExtraContent = false;
 const items = [{}, {}, {}, {}, {}, {}]
 
 function onButtonTap(event) {
-    $closeBottomSheet(event.object.id);
+    closeBottomSheet(event.object.id);
 }
 
 function onShownInBottomSheet(args) {
@@ -51,7 +40,7 @@ function toggleExtraContent() {
 }
 
 function openAnotherInner() {
-    $showBottomSheet(BottomSheetInnerKeyboardVue, {
+    showBottomSheet(BottomSheetInnerKeyboardVue, {
         // transparent:true,
         ignoreBottomSafeArea: true,
         closeCallback: (...args) => {

--- a/demo-snippets/vue3/BottomSheetInner.vue
+++ b/demo-snippets/vue3/BottomSheetInner.vue
@@ -12,6 +12,13 @@
                 <MDTextField hint="Edit text to filter..." style="font-size: 16" />
                 <MDActivityIndicator *ngIf="processing" width="50" height="50" />
             </StackLayout>
+            <ListView height="150" :items="items" id="scrollView">
+                <GridLayout height="64" backgroundColor="green">
+                    <Image horizontalAlignment="left" width="64" />
+                    <Label horizontalAlignment="center" />
+                    <Label horizontalAlignment="right" />
+                </GridLayout>
+            </ListView>
             <Button text="Cancel" horizontalAlignment="center" />
         </StackLayout>
     </GridLayout>
@@ -21,8 +28,9 @@
 import BottomSheetInnerKeyboardVue from './BottomSheetInnerKeyboard.vue';
 import { useBottomSheet } from "@nativescript-community/ui-material-bottomsheet/vue3";
 const { showBottomSheet, closeBottomSheet } = useBottomSheet()
+import { ref } from 'nativescript-vue';
 
-const showExtraContent = false;
+const showExtraContent = ref(false);
 const items = [{}, {}, {}, {}, {}, {}]
 
 function onButtonTap(event) {
@@ -34,7 +42,7 @@ function onShownInBottomSheet(args) {
 }
 
 function toggleExtraContent() {
-    showExtraContent = !showExtraContent;
+    showExtraContent.value = !showExtraContent.value;
 }
 
 function openAnotherInner() {

--- a/demo-snippets/vue3/BottomSheetInner.vue
+++ b/demo-snippets/vue3/BottomSheetInner.vue
@@ -2,6 +2,7 @@
     <GridLayout id="test1" rows="auto auto" backgroundColor="yellow">
         <!-- highlighted in red to demonstrate movement -->
         <Stacklayout id="test2" row="0" backgroundColor="red" verticalAlignment="top" marginLeft="10" marginRight="10">
+            <Button @tap="$emit('indexChanged', 200)" text="Emit value"></Button>
             <Button @tap="toggleExtraContent" text="Toggle extra content"></Button>
             <Button @tap="openAnotherInner" text="Open second"></Button>
             <Button id="innerButton" @tap="onButtonTap" text="close with result"></Button>
@@ -26,38 +27,36 @@
     <!-- </MDCardView> -->
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import * as frameModule from '@nativescript/core/ui/frame';
-import Vue from 'vue';
-import NativeScriptVue from 'nativescript-vue';
 import BottomSheetInnerKeyboardVue from './BottomSheetInnerKeyboard.vue';
+import { inject } from 'vue';
 
-export default Vue.extend({
-    data() {
-        return {
-            showExtraContent: false,
-            items: [{}, {}, {}, {}, {}, {}]
-        };
-    },
-    methods: {
-        onButtonTap(event) {
-            this.$closeBottomSheet(event.object.id);
-        },
-        onShownInBottomSheet(args) {
-            console.log('onShownInBottomSheet');
-        },
-        toggleExtraContent() {
-            this.showExtraContent = !this.showExtraContent;
-        },
-        openAnotherInner() {
-            (this as NativeScriptVue).$showBottomSheet(BottomSheetInnerKeyboardVue, {
-                // transparent:true,
-                ignoreBottomSafeArea: true,
-                closeCallback: (...args) => {
-                    console.log('bottom sheet closed', args);
-                }
-            });
+const $closeBottomSheet = inject('$closeBottomSheet');
+const $showBottomSheet = inject('$showBottomSheet');
+
+const showExtraContent = false;
+const items = [{}, {}, {}, {}, {}, {}]
+
+function onButtonTap(event) {
+    $closeBottomSheet(event.object.id);
+}
+
+function onShownInBottomSheet(args) {
+    console.log('onShownInBottomSheet');
+}
+
+function toggleExtraContent() {
+    showExtraContent = !showExtraContent;
+}
+
+function openAnotherInner() {
+    $showBottomSheet(BottomSheetInnerKeyboardVue, {
+        // transparent:true,
+        ignoreBottomSafeArea: true,
+        closeCallback: (...args) => {
+            console.log('bottom sheet closed', args);
         }
-    }
-});
+    });
+}
 </script>

--- a/demo-snippets/vue3/BottomSheetInner.vue
+++ b/demo-snippets/vue3/BottomSheetInner.vue
@@ -15,11 +15,9 @@
             <Button text="Cancel" horizontalAlignment="center" />
         </StackLayout>
     </GridLayout>
-    <!-- </MDCardView> -->
 </template>
 
 <script lang="ts" setup>
-import * as frameModule from '@nativescript/core/ui/frame';
 import BottomSheetInnerKeyboardVue from './BottomSheetInnerKeyboard.vue';
 import { useBottomSheet } from "@nativescript-community/ui-material-bottomsheet/vue3";
 const { showBottomSheet, closeBottomSheet } = useBottomSheet()

--- a/demo-snippets/vue3/BottomSheetInnerKeyboard.vue
+++ b/demo-snippets/vue3/BottomSheetInnerKeyboard.vue
@@ -4,7 +4,6 @@
             <Button id="innerButtonK" @tap="onButtonTap" text="close with result k"></Button>
         </Stacklayout>
         <MDTextField margin="10" variant="filled" hint="Working TextView hint 🤪" />
-        <PreviousNextView />
     </StackLayout>
 </template>
 

--- a/demo-snippets/vue3/BottomSheetInnerKeyboard.vue
+++ b/demo-snippets/vue3/BottomSheetInnerKeyboard.vue
@@ -8,21 +8,17 @@
     </StackLayout>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import * as frameModule from '@nativescript/core/ui/frame';
-import Vue from 'vue';
+import { inject } from 'vue';
 
-export default Vue.extend({
-    data() {
-        return {};
-    },
-    methods: {
-        onShownInBottomSheet(args) {
-            console.log('onShownInBottomSheet');
-        },
-        onButtonTap(event) {
-            this.$closeBottomSheet(event.object.id);
-        }
-    }
-});
+const $closeBottomSheet = inject('$closeBottomSheet');
+
+function onShownInBottomSheet(args) {
+    console.log('onShownInBottomSheet');
+}
+
+function onButtonTap(event) {
+    $closeBottomSheet(event.object.id);
+}
 </script>

--- a/demo-snippets/vue3/BottomSheetInnerKeyboard.vue
+++ b/demo-snippets/vue3/BottomSheetInnerKeyboard.vue
@@ -10,15 +10,14 @@
 
 <script lang="ts" setup>
 import * as frameModule from '@nativescript/core/ui/frame';
-import { inject } from 'vue';
-
-const $closeBottomSheet = inject('$closeBottomSheet');
+import { useBottomSheet } from "@nativescript-community/ui-material-bottomsheet/vue3";
+const { showBottomSheet, closeBottomSheet } = useBottomSheet()
 
 function onShownInBottomSheet(args) {
     console.log('onShownInBottomSheet');
 }
 
 function onButtonTap(event) {
-    $closeBottomSheet(event.object.id);
+    closeBottomSheet(event.object.id);
 }
 </script>

--- a/demo-snippets/vue3/install.ts
+++ b/demo-snippets/vue3/install.ts
@@ -4,7 +4,7 @@ import ActivityIndicatorPlugin from '@nativescript-community/ui-material-activit
 import BottomNavigationPlugin from '@nativescript-community/ui-material-bottom-navigation/vue';
 import BottomNavigationBarPlugin from '@nativescript-community/ui-material-bottomnavigationbar/vue';
 import { install as installBottomSheet } from '@nativescript-community/ui-material-bottomsheet';
-/*import {BottomSheetPlugin} from '@nativescript-community/ui-material-bottomsheet/vue3';*/
+import { BottomSheetPlugin } from '@nativescript-community/ui-material-bottomsheet/vue3';
 import ButtonPlugin from '@nativescript-community/ui-material-button/vue';
 
 import CardViewPlugin from '@nativescript-community/ui-material-cardview/vue';
@@ -72,7 +72,7 @@ export function installPlugin(app: any) {
     app.use(TextFieldPlugin);
     app.use(TextViewPlugin);
     // TODO: wait for publish new version BottomSheetPlugin
-    //app.use(BottomSheetPlugin);
+    app.use(BottomSheetPlugin);
 }
 
 export const demos = [
@@ -88,7 +88,7 @@ export const demos = [
     { name: 'SnackBar', path: 'SnackBar', component: SnackBar },
     { name: 'TextFields', path: 'TextFields', component: TextFields },
     { name: 'TextViews', path: 'TextViews', component: TextViews },
-    // { name: 'BottomSheet', path: 'BottomSheet', component: BottomSheet },
+    { name: 'BottomSheet', path: 'BottomSheet', component: BottomSheet },
     // { name: 'SpeedDial', path: 'SpeedDial', component: SpeedDial },
     // { name: 'Tabs', path: 'Tabs', component: Tabs },
     { name: 'Mixins', path: 'Mixins', component: Mixins }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "workspaces": [
         "packages/*",
         "demo-vue",
+        "demo-vue3",
         "demo-ng",
         "demo-svelte",
         "demo-react",

--- a/packages/bottomsheet/README.md
+++ b/packages/bottomsheet/README.md
@@ -137,6 +137,15 @@ import MyComponent from 'MyComponent.vue';
 
 //inside another Vue component
 const options: VueBottomSheetOptions = {
+    // props to be passed to MyComponent
+    props: {
+        someProp: true,
+        anotherProp: false
+    },
+    // listeners to be connected to MyComponent
+    on: {
+        someEvent: (value) => { console.log(value) }
+    }
 };
 this.$showBottomSheet(MyComponent, options)
 ```
@@ -158,7 +167,15 @@ import MyComponent from 'MyComponent.vue';
 
 
 const options: VueBottomSheetOptions = {
-    ...
+    // props to be passed to MyComponent
+    props: {
+        someProp: true,
+        anotherProp: false
+    },
+    // listeners to be connected to MyComponent
+    on: {
+        someEvent: (value) => { console.log(value) }
+    }
 };
 
 const { showBottomSheet, closeBottomSheet } = useBottomSheet()

--- a/src/bottomsheet/vue/index.ts
+++ b/src/bottomsheet/vue/index.ts
@@ -5,6 +5,7 @@ import { View } from '@nativescript/core';
 
 export interface VueBottomSheetOptions extends Omit<BottomSheetOptions, 'view'> {
     props?: any;
+    on?: Record<string, (...args: any[]) => any>;
 }
 
 declare module 'nativescript-vue' {
@@ -43,6 +44,7 @@ const BottomSheetPlugin = {
                     render: (h) =>
                         h(component, {
                             props: options.props,
+                            on: options.on,
                             key: serializeModalOptions(options)
                         })
                 });

--- a/src/bottomsheet/vue3/index.ts
+++ b/src/bottomsheet/vue3/index.ts
@@ -26,9 +26,20 @@ const showSheet = (component, options: VueBottomSheetOptions) =>
     new Promise((resolve: any) => {
         let resolved = false;
 
-        let navEntryInstance = createNativeView(component, {
-            props: options.props
-        }).mount();
+        const listeners = Object.entries(options.on ?? {}).reduce((listeners, [key, value]) => {
+            listeners['on' + key.charAt(0).toUpperCase() + key.slice(1)] = value;
+            return listeners;
+        }, {});
+
+        let navEntryInstance = createNativeView(
+            component,
+            Object.assign(
+                {
+                    props: options.props
+                },
+                listeners
+            )
+        ).mount();
 
         const viewAttached = (options.view as View) ?? Frame.topmost().currentPage;
 
@@ -66,6 +77,8 @@ const BottomSheetPlugin = {
 
         globals.$showBottomSheet = showSheet;
         globals.$closeBottomSheet = closeSheet;
+        app.provide('$showBottomSheet', showSheet);
+        app.provide('$closeBottomSheet', closeSheet);
     }
 };
 
@@ -75,6 +88,7 @@ const createNativeView = (component: any, props?: any): App => createApp(compone
 interface VueBottomSheetOptions extends Partial<BottomSheetOptions> {
     view?: string | ViewBase;
     props?: any;
+    on?: Record<string, (...args: any[]) => any>;
 }
 
 export { BottomSheetPlugin, VueBottomSheetOptions, useBottomSheet };

--- a/src/bottomsheet/vue3/index.ts
+++ b/src/bottomsheet/vue3/index.ts
@@ -77,8 +77,6 @@ const BottomSheetPlugin = {
 
         globals.$showBottomSheet = showSheet;
         globals.$closeBottomSheet = closeSheet;
-        app.provide('$showBottomSheet', showSheet);
-        app.provide('$closeBottomSheet', closeSheet);
     }
 };
 


### PR DESCRIPTION
Currently the only way to get an update from  the bottomsheet vue component is via directly calling the $closeBottomSheet method with some return arguments.  

However, when a user swipes to close the bottomsheet there is no opportunity for us to call $closeBottomSheet.  

This pull request adds the ability to directly apply listeners to the vue component in the bottomsheet so that we can get updates from it.