### PR TITLE
fix(android): application breaks when adapter is null

### DIFF
--- a/packages/core-tabs/platforms/android/java/com/nativescript/material/core/TabsBar.java
+++ b/packages/core-tabs/platforms/android/java/com/nativescript/material/core/TabsBar.java
@@ -178,7 +178,7 @@ public class TabsBar extends HorizontalScrollView {
     public void setItems(TabItemSpec[] items) {
         mTabStrip.removeAllViews();
         mTabItems = items;
-        if (mViewPager != null) {
+        if (mViewPager != null && mViewPager.getAdapter() != null) {
             populateTabStrip();
         }
         


### PR DESCRIPTION
When you enter a view with tabs and go back a page, if you exit the application and enter again we have this error:

```
  System.err: An uncaught Exception occurred on "main" thread.
  System.err: Calling js method onStart failed
  System.err: Error: java.lang.NullPointerException: Attempt to invoke virtual method 'int androidx.viewpager2.adapter.FragmentStateAdapter.getItemCount()' on a null object reference
  System.err:
  System.err: StackTrace:
  System.err: setTabBarItems(file: src/webpack:/abll-app/node_modules/@nativescript-community/ui-material-tabs/index.android.js:74:0)
  System.err:   at setTabStripItems(file: src/webpack:/abll-app/node_modules/@nativescript-community/ui-material-core-tabs/tab-navigation/index.android.js:321:0)
  System.err:   at setTabStripItems(file: src/webpack:/abll-app/node_modules/@nativescript-community/ui-material-tabs/index.android.js:90:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@nativescript-community/ui-material-core-tabs/tab-navigation/index.android.js:257:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@nativescript-community/ui-material-tabs/index.android.js:93:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at callFunctionWithSuper(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:323:0)
  System.err:   at callLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at loadView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:478:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:245:0)
  System.err:   at eachChildView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/layouts/layout-base-common.js:101:0)
  System.err:   at eachChild(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/view-common.js:784:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:244:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/view-common.js:113:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/index.android.js:305:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at callFunctionWithSuper(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:323:0)
  System.err:   at callLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at loadView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:478:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:245:0)
  System.err:   at eachChildView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/layouts/layout-base-common.js:101:0)
  System.err:   at eachChild(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/view-common.js:784:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:244:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/view-common.js:113:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/index.android.js:305:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at callFunctionWithSuper(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:323:0)
  System.err:   at callLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at loadView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:478:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:245:0)
  System.err:   at eachChildView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/content-view/index.js:65:0)
  System.err:   at eachChildView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/page/page-common.js:107:0)
  System.err:   at eachChild(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/view-common.js:784:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:244:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/view-common.js:113:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/index.android.js:305:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/page/index.android.js:38:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at callFunctionWithSuper(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:323:0)
  System.err:   at callLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at loadView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:478:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:245:0)
  System.err:   at eachChildView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/frame/frame-common.js:432:0)
  System.err:   at eachChild(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/view-common.js:784:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:244:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/view-common.js:113:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/index.android.js:305:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/frame/frame-common.js:90:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at callFunctionWithSuper(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:323:0)
  System.err:   at callLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at loadView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:478:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:245:0)
  System.err:   at eachChildView(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/layouts/layout-base-common.js:101:0)
  System.err:   at eachChild(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/view-common.js:784:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:244:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/view-common.js:113:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view/index.android.js:305:0)
  System.err:   at onLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/layouts/root-layout/root-layout-common.js:16:0)
  System.err:   at (file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at callFunctionWithSuper(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:323:0)
  System.err:   at callLoaded(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/core/view-base/index.js:329:0)
  System.err:   at onStart(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/frame/index.android.js:997:0)
  System.err:   at onStart(file: src/webpack:/abll-app/node_modules/@akylas/nativescript/ui/frame/activity.android.js:30:0)
  System.err:   at com.tns.Runtime.callJSMethodNative(Native Method)
  System.err:   at com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1302)
  System.err:   at com.tns.Runtime.callJSMethodImpl(Runtime.java:1188)
  System.err:   at com.tns.Runtime.callJSMethod(Runtime.java:1175)
  System.err:   at com.tns.Runtime.callJSMethod(Runtime.java:1153)
  System.err:   at com.tns.Runtime.callJSMethod(Runtime.java:1149)
  System.err:   at com.tns.NativeScriptActivity.onStart(NativeScriptActivity.java:33)
  System.err:   at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1511)
  System.err:   at android.app.Activity.performStart(Activity.java:8489)
  System.err:   at android.app.ActivityThread.handleStartActivity(ActivityThread.java:3800)
  System.err:   at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:221)
  System.err:   at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:201)
  System.err:   at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:183)
  System.err:   at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:132)
  System.err:   at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
  System.err:   at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2363)
  System.err:   at android.os.Handler.dispatchMessage(Handler.java:106)
  System.err:   at android.os.Looper.loopOnce(Looper.java:210)
  System.err:   at android.os.Looper.loop(Looper.java:299)
  System.err:   at android.app.ActivityThread.main(ActivityThread.java:8116)
  System.err:   at java.lang.reflect.Method.invoke(Native Method)
  System.err:   at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:559)
  System.err:   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
  System.err: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int androidx.viewpager2.adapter.FragmentStateAdapter.getItemCount()' on a null object reference
  System.err:   at com.nativescript.material.core.TabsBar.populateTabStrip(TabsBar.java:341)
  System.err:   at com.nativescript.material.core.TabsBar.setItems(TabsBar.java:182)
  System.err:   ... 23 more
```

https://user-images.githubusercontent.com/15719383/227709526-c4b96925-b814-4474-b483-10ab3e32cbc3.mp4



I'm not sure why if we have navigated back the instance of the tabs is still running. I would say this is caused by a memory leak. Anyway, this change fixes the bug and the app doesn't break
