### PR TITLE
fix(tabs): NSArray Indexing

### DIFF
--- a/src/tabs/index.ios.ts
+++ b/src/tabs/index.ios.ts
@@ -207,7 +207,7 @@ class UIPageViewControllerImpl extends UIPageViewController {
         let scrollView: UIScrollView = null;
 
         for (let i = 0; i < subViews.count; i++) {
-            const view: UIView = subViews[i];
+            const view: UIView = subViews.objectAtIndex(i);
             if (view instanceof UIScrollView && !(view instanceof MDCTabBarView)) {
                 scrollView = view;
             }


### PR DESCRIPTION
Use `objectAtIndex` to index into NSArray, fixing issue with IOS for NS 8.5