### PR TITLE
[bottom-navigation] Fixe IOS icon color

### DIFF
--- a/src/bottom-navigation/index.ios.ts
+++ b/src/bottom-navigation/index.ios.ts
@@ -695,8 +695,8 @@ export class BottomNavigation extends TabNavigationBase {
         if (!image) {
             let is: ImageSource | ImageAsset;
             if (typeof iconSource === 'string') {
-                isFontIcon = true;
                 if (Utils.isFontIconURI(iconSource)) {
+                    isFontIcon = true;
                     const fontIconCode = iconSource.split('//')[1];
                     const target = tabStripItem.image ? tabStripItem.image : tabStripItem;
                     const font = target.style.fontInternal;

--- a/src/bottom-navigation/index.ios.ts
+++ b/src/bottom-navigation/index.ios.ts
@@ -690,11 +690,12 @@ export class BottomNavigation extends TabNavigationBase {
         }
         const iconTag = [iconSource, font.fontStyle, font.fontWeight, font.fontSize, font.fontFamily, color].join(';');
 
-        const isFontIcon = false;
+        let isFontIcon = false;
         let image: UIImage = this.mIconsCache[iconTag];
         if (!image) {
             let is: ImageSource | ImageAsset;
             if (typeof iconSource === 'string') {
+                isFontIcon = true;
                 if (Utils.isFontIconURI(iconSource)) {
                     const fontIconCode = iconSource.split('//')[1];
                     const target = tabStripItem.image ? tabStripItem.image : tabStripItem;


### PR DESCRIPTION
In IOS the icon color doesn't change correctly is seems that is due to a miss in the code.

`isFontIcon` is not set correctly if the image type is a font icon .. and it was set as constant also!