### PR TITLE
fix: support both old and new gridlayout addRow APIs

### DIFF
--- a/src/core-tabs/tab-content-item/index.android.ts
+++ b/src/core-tabs/tab-content-item/index.android.ts
@@ -1,4 +1,5 @@
 import { GridLayout, Trace, View } from '@nativescript/core';
+import { addGridLayoutRow } from '@nativescript-community/ui-material-core/android/utils';
 import { TabContentItem as TabContentItemDefinition } from '.';
 import { TabContentItemBase } from './tab-content-item-common';
 
@@ -14,7 +15,7 @@ export class TabContentItem extends TabContentItemBase {
 
     public createNativeView() {
         const layout = new org.nativescript.widgets.GridLayout(this._context);
-        layout.addRow(1, org.nativescript.widgets.GridUnitType.star);
+        addGridLayoutRow(layout, 1, org.nativescript.widgets.GridUnitType.star);
 
         return layout;
     }

--- a/src/core-tabs/tab-navigation/index.android.ts
+++ b/src/core-tabs/tab-navigation/index.android.ts
@@ -1,4 +1,5 @@
 import { Application, Color, CoreTypes, Font, ImageAsset, ImageSource, Utils, getTransformedText } from '@nativescript/core';
+import { addGridLayoutRow } from '@nativescript-community/ui-material-core/android/utils';
 import { TabContentItem } from '../tab-content-item';
 import { getIconSpecSize, itemsProperty, selectedIndexProperty, tabStripProperty } from '../tab-navigation-base';
 import { TabStrip } from '../tab-strip';
@@ -222,13 +223,13 @@ export abstract class TabNavigation<T extends android.view.ViewGroup = any> exte
         const lp = new org.nativescript.widgets.CommonLayoutParams();
         lp.row = 1;
         if (this.tabsPosition === 'top') {
-            nativeView.addRow(1, org.nativescript.widgets.GridUnitType.auto);
-            nativeView.addRow(1, org.nativescript.widgets.GridUnitType.star);
+            addGridLayoutRow(nativeView, 1, org.nativescript.widgets.GridUnitType.auto);
+            addGridLayoutRow(nativeView, 1, org.nativescript.widgets.GridUnitType.star);
 
             viewPager.setLayoutParams(lp);
         } else {
-            nativeView.addRow(1, org.nativescript.widgets.GridUnitType.star);
-            nativeView.addRow(1, org.nativescript.widgets.GridUnitType.auto);
+            addGridLayoutRow(nativeView, 1, org.nativescript.widgets.GridUnitType.star);
+            addGridLayoutRow(nativeView, 1, org.nativescript.widgets.GridUnitType.auto);
             this.tabBarLayoutParams = lp;
         }
 

--- a/src/core/android/utils.ts
+++ b/src/core/android/utils.ts
@@ -263,3 +263,23 @@ export function inflateLayout(context: android.content.Context, layoutId: string
     }
     return NUtils.inflateLayout(context, layoutId);
 }
+
+let isNewGridAPI: boolean | undefined;
+
+export function addGridLayoutRow(gridLayout: org.nativescript.widgets.GridLayout, value: number, unitType: org.nativescript.widgets.GridUnitType) {
+    if (isNewGridAPI === undefined) {
+        try {
+            gridLayout.addRow(value, unitType);
+            isNewGridAPI = true;
+            return;
+        } catch (e) {
+            isNewGridAPI = false;
+        }
+    }
+    if (isNewGridAPI) {
+        gridLayout.addRow(value, unitType);
+    } else {
+        // @ts-expect-error older API
+        gridLayout.addRow(new org.nativescript.widgets.ItemSpec(value, unitType));
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,7 +3590,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-activityindicator@workspace:packages/activityindicator"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3598,8 +3598,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-bottom-navigation@workspace:packages/bottom-navigation"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
-    "@nativescript-community/ui-material-core-tabs": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
+    "@nativescript-community/ui-material-core-tabs": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3607,7 +3607,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-bottomnavigationbar@workspace:packages/bottomnavigationbar"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3615,16 +3615,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-bottomsheet@workspace:packages/bottomsheet"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
-"@nativescript-community/ui-material-button@npm:*, @nativescript-community/ui-material-button@npm:^7.2.68, @nativescript-community/ui-material-button@workspace:packages/button":
+"@nativescript-community/ui-material-button@npm:*, @nativescript-community/ui-material-button@npm:^7.2.69, @nativescript-community/ui-material-button@workspace:packages/button":
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-button@workspace:packages/button"
   dependencies:
     "@nativescript-community/text": "npm:^1.5.2"
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3632,7 +3632,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-cardview@workspace:packages/cardview"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3645,15 +3645,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nativescript-community/ui-material-core-tabs@npm:*, @nativescript-community/ui-material-core-tabs@npm:^7.2.68, @nativescript-community/ui-material-core-tabs@workspace:packages/core-tabs":
+"@nativescript-community/ui-material-core-tabs@npm:*, @nativescript-community/ui-material-core-tabs@npm:^7.2.69, @nativescript-community/ui-material-core-tabs@workspace:packages/core-tabs":
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-core-tabs@workspace:packages/core-tabs"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
-"@nativescript-community/ui-material-core@npm:*, @nativescript-community/ui-material-core@npm:^7.2.68, @nativescript-community/ui-material-core@workspace:packages/core":
+"@nativescript-community/ui-material-core@npm:*, @nativescript-community/ui-material-core@npm:^7.2.69, @nativescript-community/ui-material-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-core@workspace:packages/core"
   languageName: unknown
@@ -3663,8 +3663,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-dialogs@workspace:packages/dialogs"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
-    "@nativescript-community/ui-material-textfield": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
+    "@nativescript-community/ui-material-textfield": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3672,7 +3672,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-floatingactionbutton@workspace:packages/floatingactionbutton"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3680,7 +3680,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-progress@workspace:packages/progress"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3688,7 +3688,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-ripple@workspace:packages/ripple"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3696,7 +3696,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-slider@workspace:packages/slider"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3704,7 +3704,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-snackbar@workspace:packages/snackbar"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3712,8 +3712,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-speeddial@workspace:packages/speeddial"
   dependencies:
-    "@nativescript-community/ui-material-button": "npm:^7.2.68"
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-button": "npm:^7.2.69"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3721,7 +3721,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-switch@workspace:packages/switch"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3729,17 +3729,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-tabs@workspace:packages/tabs"
   dependencies:
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
-    "@nativescript-community/ui-material-core-tabs": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
+    "@nativescript-community/ui-material-core-tabs": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
-"@nativescript-community/ui-material-textfield@npm:*, @nativescript-community/ui-material-textfield@npm:^7.2.68, @nativescript-community/ui-material-textfield@workspace:packages/textfield":
+"@nativescript-community/ui-material-textfield@npm:*, @nativescript-community/ui-material-textfield@npm:^7.2.69, @nativescript-community/ui-material-textfield@workspace:packages/textfield":
   version: 0.0.0-use.local
   resolution: "@nativescript-community/ui-material-textfield@workspace:packages/textfield"
   dependencies:
     "@nativescript-community/text": "npm:^1.5.33"
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 
@@ -3748,7 +3748,7 @@ __metadata:
   resolution: "@nativescript-community/ui-material-textview@workspace:packages/textview"
   dependencies:
     "@nativescript-community/text": "npm:^1.5.33"
-    "@nativescript-community/ui-material-core": "npm:^7.2.68"
+    "@nativescript-community/ui-material-core": "npm:^7.2.69"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
fixes the issue introduced in https://github.com/nativescript-community/ui-material-components/commit/72e442da0c84f42826af14f4fbfb497ab619a7d9#r151328451 when using a non-latest core version