### PR TITLE
fix(core-tabs): tab bar background color not applying on `tabStripItems`

### DIFF
--- a/src/core-tabs/tab-navigation/index.android.ts
+++ b/src/core-tabs/tab-navigation/index.android.ts
@@ -552,6 +552,9 @@ export abstract class TabNavigation<T extends android.view.ViewGroup = any> exte
         } else {
             this.mTabsBar.setBackground(tryCloneDrawable(value, this.nativeViewProtected.getResources()));
         }
+        this.tabStrip.items?.forEach((item) => {
+            this.updateItem(item);
+        });
     }
 
     public getTabBarHighlightColor(): number {


### PR DESCRIPTION
Call update item for tab strip items so that the background color from tab bar is reflected to the items.